### PR TITLE
Test that every codemod can be rerun without harm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.log
 .idea
 node_modules
 coverage

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,9 @@
+instrumentation:
+  root: transforms
+  include-all-sources: true
+check:
+  global:
+    statements: 98.36
+    branches: 85.19
+    functions: 100
+    lines: 98.31

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - 4
+script:
+  - npm test
+sudo: false
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - 4
 script:
-  - npm test
+  - npm run test-cov
 sudo: false
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "A collection of js transforms using jscodeshift",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test",
-    "test-cov": "istanbul cover _mocha -- test",
-    "test-watch": "mocha --watch --reporter min test"
+    "test": "mocha",
+    "test-cov": "istanbul cover _mocha && istanbul check-coverage",
+    "test-watch": "mocha --watch --reporter min"
   },
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/Springworks/js-transforms#readme",
   "devDependencies": {
-    "istanbul": "^0.4.0",
+    "istanbul": "^0.4.1",
     "jscodeshift": "^0.3.9",
     "mocha": "^2.3.4"
   }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha test",
+    "test-cov": "istanbul cover _mocha -- test",
     "test-watch": "mocha --watch --reporter min test"
   },
   "repository": {
@@ -18,7 +19,8 @@
   },
   "homepage": "https://github.com/Springworks/js-transforms#readme",
   "devDependencies": {
-    "jscodeshift": "0.3.8",
-    "mocha": "2.3.3"
+    "istanbul": "^0.4.0",
+    "jscodeshift": "^0.3.9",
+    "mocha": "^2.3.4"
   }
 }

--- a/test-fixtures/migrate-error-factory/migrate-error-factory-01.js
+++ b/test-fixtures/migrate-error-factory/migrate-error-factory-01.js
@@ -1,6 +1,11 @@
 var createError = require('@springworks/error-factory').create;
 
+createError();
+createError(400);
+
 exports.someFunction = function(callback) {
+  createError();
+
   doTheThing(function(err, val) {
     if (err) {
       callback(createError(500, 'Oh no!'));

--- a/test-fixtures/migrate-error-factory/migrate-error-factory-01.output.js
+++ b/test-fixtures/migrate-error-factory/migrate-error-factory-01.output.js
@@ -1,6 +1,13 @@
 var createError = require('@springworks/error-factory').createError;
 
+createError({});
+createError({
+  code: 400
+});
+
 exports.someFunction = function(callback) {
+  createError({});
+
   doTheThing(function(err, val) {
     if (err) {
       callback(createError({

--- a/test-fixtures/migrate-error-factory/migrate-error-factory-03.output.js
+++ b/test-fixtures/migrate-error-factory/migrate-error-factory-03.output.js
@@ -3,7 +3,7 @@ var ErrorFactory = require('@springworks/error-factory');
 exports.someFunction = function(callback) {
   doTheThing(function(err, val) {
     if (err) {
-      callback(ErrorFactory.create({
+      callback(ErrorFactory.createError({
         code: 500,
         message: 'Oh no!',
         cause: err

--- a/test-fixtures/migrate-error-factory/migrate-error-factory-04.output.js
+++ b/test-fixtures/migrate-error-factory/migrate-error-factory-04.output.js
@@ -7,7 +7,7 @@ exports.someFunction = function() {
 
 function handleError(err) {
   log(err, 'Log message');
-  throw ErrorFactory.create({
+  throw ErrorFactory.createError({
     code: 500,
     message: 'Oh no!',
     cause: err

--- a/test-fixtures/migrate-error-factory/migrate-error-factory-06.js
+++ b/test-fixtures/migrate-error-factory/migrate-error-factory-06.js
@@ -1,0 +1,22 @@
+import { create as localName } from '@springworks/error-factory';
+
+exports.someFunction = function(callback) {
+  doTheThing(function(err, val) {
+    if (err) {
+      callback(localName(500, 'Oh no!'));
+      return;
+    }
+
+    callback(null, val);
+  });
+};
+
+exports.someFunction = function() {
+  return doTheThing().catch(handleError);
+};
+
+
+function handleError(err) {
+  log(err, 'Log message');
+  throw localName(500, 'Oh no!');
+}

--- a/test-fixtures/migrate-error-factory/migrate-error-factory-06.output.js
+++ b/test-fixtures/migrate-error-factory/migrate-error-factory-06.output.js
@@ -1,0 +1,30 @@
+import { createError as localName } from '@springworks/error-factory';
+
+exports.someFunction = function(callback) {
+  doTheThing(function(err, val) {
+    if (err) {
+      callback(localName({
+        code: 500,
+        message: 'Oh no!',
+        cause: err
+      }));
+      return;
+    }
+
+    callback(null, val);
+  });
+};
+
+exports.someFunction = function() {
+  return doTheThing().catch(handleError);
+};
+
+
+function handleError(err) {
+  log(err, 'Log message');
+  throw localName({
+    code: 500,
+    message: 'Oh no!',
+    cause: err
+  });
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
 --ui bdd
 --check-leaks
 --reporter dot
+--inline-diffs

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--ui bdd
+--check-leaks
+--reporter dot

--- a/transforms/migrate-error-factory.js
+++ b/transforms/migrate-error-factory.js
@@ -53,7 +53,10 @@ function transformRequiredWithObject(j, modified, root, require_calls) {
   filtered.forEach(path => {
     const local_name = path.parentPath.value.id.name;
     const usage = root.find(j.MemberExpression, { object: { name: local_name }, property: { name: 'create' } });
-    usage.forEach(p => transformCallExpressionToCreate(j, p.parentPath));
+    usage.forEach(p => {
+      p.value.property.name = 'createError';
+      transformCallExpressionToCreate(j, p.parentPath);
+    });
     modified(usage.size() > 0);
   });
 }


### PR DESCRIPTION
A codemod should be safe to run several times. It should not modify the code if you run it again.

This adds a test case for each fixture that runs the transformer on the output file and asserts that no changes have been made.

When adding these tests I also discovered a bug in `migrate-error-factory`:

When `error-factory` was required as an object (`const name = require(...);`) then the `create` method was not properly replaced with the `createError` method.

Now it should be safe to rerun `migrate-error-factory` several times.
