### PR TITLE
Always use the value from `catch` as error cause

### DIFF
--- a/transforms/migrate-error-factory.js
+++ b/transforms/migrate-error-factory.js
@@ -118,7 +118,7 @@ function findErrorIdentifier(path) {
         return path.value.params[0];
       }
     }
-    if (path.value.type === 'CatchClause' && nameMightBeAnError(path.value.param.name)) {
+    if (path.value.type === 'CatchClause') {
       return path.value.param;
     }
   }


### PR DESCRIPTION
No need to check the name of the error from a `catch` clause, it will always be an error.